### PR TITLE
Feature/te 387 add tml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ You can also configure the versions of the languages individually:
 
 	testeditor {
 		amlVersion '1.0.0'
+		tmlVersion '1.0.0'
 		tclVersion '1.0.0'
 		tslVersion '1.0.0'
 	}

--- a/src/main/groovy/org/testeditor/gradle/plugin/TesteditorBasePlugin.groovy
+++ b/src/main/groovy/org/testeditor/gradle/plugin/TesteditorBasePlugin.groovy
@@ -33,6 +33,9 @@ class TesteditorBasePlugin implements Plugin<Project> {
                 aml {
                     setup = 'org.testeditor.aml.dsl.AmlStandaloneSetup'
                 }
+                tml {
+                    setup = 'org.testeditor.tml.dsl.TmlStandaloneSetup'
+                }
                 tcl {
                     setup = 'org.testeditor.tcl.dsl.TclStandaloneSetup'
                     generator.outlet.producesJava = true
@@ -47,10 +50,13 @@ class TesteditorBasePlugin implements Plugin<Project> {
         // TODO we could improve this by not using the common xtextLanguages
         project.afterEvaluate {
             def amlVersion = project.testeditor.amlVersion ?: project.testeditor.version
+            def tmlVersion = project.testeditor.tmlVersion ?: project.testeditor.version
             def tclVersion = project.testeditor.tclVersion ?: project.testeditor.version
             def tslVersion = project.testeditor.tslVersion ?: project.testeditor.version
             project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.aml.model:${amlVersion}")
             project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.aml.dsl:${amlVersion}")
+            project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.tml.model:${tmlVersion}")
+            project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.tml.dsl:${tmlVersion}")
             project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.tcl.model:${tclVersion}")
             project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.tcl.dsl:${tclVersion}")
             project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.tsl.model:${tslVersion}")

--- a/src/main/groovy/org/testeditor/gradle/plugin/TesteditorBasePlugin.groovy
+++ b/src/main/groovy/org/testeditor/gradle/plugin/TesteditorBasePlugin.groovy
@@ -49,10 +49,12 @@ class TesteditorBasePlugin implements Plugin<Project> {
         // Add dependencies
         // TODO we could improve this by not using the common xtextLanguages
         project.afterEvaluate {
-            def amlVersion = project.testeditor.amlVersion ?: project.testeditor.version
-            def tmlVersion = project.testeditor.tmlVersion ?: project.testeditor.version
-            def tclVersion = project.testeditor.tclVersion ?: project.testeditor.version
-            def tslVersion = project.testeditor.tslVersion ?: project.testeditor.version
+            def testEditorVersion = project.testeditor.version
+            def amlVersion = project.testeditor.amlVersion ?: testEditorVersion
+            def tmlVersion = project.testeditor.tmlVersion ?: testEditorVersion
+            def tclVersion = project.testeditor.tclVersion ?: testEditorVersion
+            def tslVersion = project.testeditor.tslVersion ?: testEditorVersion
+            project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.dsl.common:${testEditorVersion}")
             project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.aml.model:${amlVersion}")
             project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.aml.dsl:${amlVersion}")
             project.dependencies.add('xtextLanguages', "org.testeditor:org.testeditor.tml.model:${tmlVersion}")

--- a/src/main/groovy/org/testeditor/gradle/plugin/TesteditorPluginExtension.groovy
+++ b/src/main/groovy/org/testeditor/gradle/plugin/TesteditorPluginExtension.groovy
@@ -16,6 +16,9 @@ class TesteditorPluginExtension {
     /** The version of TCL to use. */
     def String tclVersion = null
 
+    /** The version of TML to use. */
+    def String tmlVersion = null
+
     /** The version of TSL to use. */
     def String tslVersion = null
 

--- a/src/test/groovy/org/testeditor/gradle/plugin/AbstractIntegrationTest.groovy
+++ b/src/test/groovy/org/testeditor/gradle/plugin/AbstractIntegrationTest.groovy
@@ -20,7 +20,7 @@ abstract class AbstractIntegrationTest extends IntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "http://dl.bintray.com/test-editor/test-dsls" }
+                maven { url "http://dl.bintray.com/test-editor/test-editor-maven" }
             }
         """.stripIndent()
     }


### PR DESCRIPTION
tests currently failing because org.testeditor:org.testeditor.tml.model:1.0.0 and org.testeditor:org.testeditor.tml.dsl:1.0.0 are not found in repo