### PR TITLE
add dependency management for Test-Editor 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,5 @@ A minimal `build.gradle` looks like this:
 The version of the test-editor can be configured as follows:
 
 	testeditor {
-	    version '1.1.0'
-	}
-
-You can also configure the versions of the languages individually:
-
-	testeditor {
-		amlVersion '1.1.0'
-		tmlVersion '1.1.0'
-		tclVersion '1.1.0'
-		tslVersion '1.1.0'
+	    version '1.2.0'
 	}

--- a/src/main/groovy/org/testeditor/gradle/plugin/TesteditorPluginExtension.groovy
+++ b/src/main/groovy/org/testeditor/gradle/plugin/TesteditorPluginExtension.groovy
@@ -8,20 +8,8 @@ class TesteditorPluginExtension {
     static final String NAME = "testeditor"
 
     /** The version of the languages to use. */
-    def String version = "1.1.0" // TODO we don't want a default value
+    def String version = "1.2.0" // TODO we don't want a default value
 
-    /** The version of AML to use. */
-    def String amlVersion = null
-
-    /** The version of TCL to use. */
-    def String tclVersion = null
-
-    /** The version of TML to use. */
-    def String tmlVersion = null
-
-    /** The version of TSL to use. */
-    def String tslVersion = null
-
-    def String xtextVersion = "2.9.1"
+    def String xtextVersion = "2.10.0"
 
 }

--- a/src/test/groovy/org/testeditor/gradle/plugin/AbstractIntegrationTest.groovy
+++ b/src/test/groovy/org/testeditor/gradle/plugin/AbstractIntegrationTest.groovy
@@ -20,7 +20,11 @@ abstract class AbstractIntegrationTest extends IntegrationSpec {
 
             repositories {
                 jcenter()
-                maven { url "http://dl.bintray.com/test-editor/test-editor-maven" }
+                maven { url "http://dl.bintray.com/test-editor/maven" }
+            }
+
+            dependencies {
+                testCompile 'org.testeditor.fixture:core-fixture:3.1.0'
             }
         """.stripIndent()
     }


### PR DESCRIPTION
This improves the plugin code and adds dependencies for the upcoming 1.2.0 release.
Also addresses issue #2 